### PR TITLE
Fix PWM demo for non-Device Tree

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -1,3 +1,5 @@
+This is the "pwm" branch for testing PWM.
+
 Pine64 BL602 SDK modded for the articles...
 
 - `"Flashing Firmware to PineCone BL602" <https://lupyuen.github.io/articles/flash>`_

--- a/customer_app/sdk_app_pwm/sdk_app_pwm/main.c
+++ b/customer_app/sdk_app_pwm/sdk_app_pwm/main.c
@@ -142,6 +142,63 @@ void cmd_pwm_init(char *buf, int len, int argc, char **argv)
     bl_pwm_init(id, pin, 6000000);
 }
 
+/*
+int32_t bl_pwm_set_duty(uint8_t id, float duty);
+int32_t bl_pwm_get_duty(uint8_t id, float *p_duty);
+int32_t bl_pwm_set_freq(uint8_t id, uint32_t freq);
+*/
+
+//  pwm_duty_set 0 20000
+void cmd_pwm_duty_set(char *buf, int len, int argc, char **argv)
+{
+    uint8_t id;
+    float   duty;
+
+    if (argc != 3) {
+        log_error("arg err.\r\n");
+        return;
+    }
+
+    id = atoi(argv[1]);
+    duty = atof(argv[2]);
+
+    bl_pwm_set_duty(id, duty);
+}
+
+//  pwm_duty_get 0
+void cmd_pwm_duty_get(char *buf, int len, int argc, char **argv)
+{
+    uint8_t  id;
+    float    duty;
+
+    if (argc != 2) {
+        log_error("arg err.\r\n");
+        return;
+    }
+
+    id = atoi(argv[1]);
+
+    bl_pwm_get_duty(id, &duty);
+    printf("pwm duty %f\r\n", duty);
+}
+
+//  pwm_freq_set 0 3000
+void cmd_pwm_freq_set(char *buf, int len, int argc, char **argv)
+{
+    uint8_t  id;
+    uint32_t freq;
+
+    if (argc != 3) {
+        log_error("arg err.\r\n");
+        return;
+    }
+
+    id = atoi(argv[1]);
+    freq = atoi(argv[2]);
+
+    bl_pwm_set_freq(id, freq);
+}
+
 void cmd_pwm_start(char *buf, int len, int argc, char **argv)
 {
     uint8_t id;
@@ -219,6 +276,9 @@ void cmd_pwm_test(char *buf, int len, int argc, char **argv)
 
 const static struct cli_command cmds_user[] STATIC_CLI_CMD_ATTRIBUTE = {
     { "pwm_init", "pwm_init 0 0", cmd_pwm_init},
+    { "pwm_duty_set", "pwm_duty_set 0 20000", cmd_pwm_duty_set},
+    { "pwm_duty_get", "pwm_duty_get 0", cmd_pwm_duty_get},
+    { "pwm_freq_set", "pwm_freq_set 0 3000", cmd_pwm_freq_set},
     { "pwm_start", "pwm_start 0", cmd_pwm_start},
     { "pwm_stop", "pwm_stop 0", cmd_pwm_stop},
     { "pwm_task", "pwm_task", cmd_pwm_task},

--- a/customer_app/sdk_app_pwm/sdk_app_pwm/main.c
+++ b/customer_app/sdk_app_pwm/sdk_app_pwm/main.c
@@ -145,7 +145,7 @@ void cmd_pwm_init(char *buf, int len, int argc, char **argv)
     bl_pwm_init(id, pin, freq);
 }
 
-//  pwm_duty_set 0 20000
+//  Set the Duty Cycle (percentage from 0 to 100): pwm_duty_set 0 50
 void cmd_pwm_duty_set(char *buf, int len, int argc, char **argv)
 {
     uint8_t id;
@@ -162,7 +162,7 @@ void cmd_pwm_duty_set(char *buf, int len, int argc, char **argv)
     bl_pwm_set_duty(id, duty);
 }
 
-//  pwm_duty_get 0
+//  Display the Duty Cycle (percentage from 0 to 100): pwm_duty_get 0
 void cmd_pwm_duty_get(char *buf, int len, int argc, char **argv)
 {
     uint8_t  id;
@@ -179,7 +179,7 @@ void cmd_pwm_duty_get(char *buf, int len, int argc, char **argv)
     printf("pwm duty %f\r\n", duty);
 }
 
-//  pwm_freq_set 0 3000
+//  Set the Frequency (2000 to 800000): pwm_freq_set 0 3000
 void cmd_pwm_freq_set(char *buf, int len, int argc, char **argv)
 {
     uint8_t  id;
@@ -273,7 +273,7 @@ void cmd_pwm_test(char *buf, int len, int argc, char **argv)
 
 const static struct cli_command cmds_user[] STATIC_CLI_CMD_ATTRIBUTE = {
     { "pwm_init", "pwm_init 0 0 3000", cmd_pwm_init},
-    { "pwm_duty_set", "pwm_duty_set 0 20000", cmd_pwm_duty_set},
+    { "pwm_duty_set", "pwm_duty_set 0 50", cmd_pwm_duty_set},
     { "pwm_duty_get", "pwm_duty_get 0", cmd_pwm_duty_get},
     { "pwm_freq_set", "pwm_freq_set 0 3000", cmd_pwm_freq_set},
     { "pwm_start", "pwm_start 0", cmd_pwm_start},

--- a/customer_app/sdk_app_pwm/sdk_app_pwm/main.c
+++ b/customer_app/sdk_app_pwm/sdk_app_pwm/main.c
@@ -130,23 +130,20 @@ void cmd_pwm_init(char *buf, int len, int argc, char **argv)
 {
     uint8_t id;
     uint8_t pin;
+    uint32_t freq;
 
-    if (argc != 3) {
+    if (argc != 4) {
         log_error("arg err.\r\n");
         return;
     }
 
     id = atoi(argv[1]);
     pin = atoi(argv[2]);
+    freq = atoi(argv[3]);
 
-    bl_pwm_init(id, pin, 6000000);
+    //  Frequency must be between 2000 and 800000
+    bl_pwm_init(id, pin, freq);
 }
-
-/*
-int32_t bl_pwm_set_duty(uint8_t id, float duty);
-int32_t bl_pwm_get_duty(uint8_t id, float *p_duty);
-int32_t bl_pwm_set_freq(uint8_t id, uint32_t freq);
-*/
 
 //  pwm_duty_set 0 20000
 void cmd_pwm_duty_set(char *buf, int len, int argc, char **argv)
@@ -275,7 +272,7 @@ void cmd_pwm_test(char *buf, int len, int argc, char **argv)
 }
 
 const static struct cli_command cmds_user[] STATIC_CLI_CMD_ATTRIBUTE = {
-    { "pwm_init", "pwm_init 0 0", cmd_pwm_init},
+    { "pwm_init", "pwm_init 0 0 3000", cmd_pwm_init},
     { "pwm_duty_set", "pwm_duty_set 0 20000", cmd_pwm_duty_set},
     { "pwm_duty_get", "pwm_duty_get 0", cmd_pwm_duty_get},
     { "pwm_freq_set", "pwm_freq_set 0 3000", cmd_pwm_freq_set},


### PR DESCRIPTION
Modified PWM commands for use without Device Tree...

- `pwm_init` command now accepts Frequency (2,000 to 800,000)...

    ````bash
    pwm_init 1 11 2000
    ````

-  Add `pwm_duty_set` and `pwm_freq_set` to set Duty Cycle (percentage from 0 to 100) and Frequency...

    ````bash
    pwm_duty_set 1 50
    pwm_freq_set 1 2000
    ````

-  Add `pwm_duty_get` to display Duty Cycle...

    ````bash
    pwm_duty_get 1
    ````
